### PR TITLE
Move dovesnap to call ovs-vsctl to configure OVS.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 FROM golang
 RUN apt-get update && apt-get -y install iptables dbus go-dep
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
+RUN apt-get update && apt-get install -y python3-pip python3 python python-setuptools make autoconf wget gcc git
+ENV OVS_VERSION 2.13.0
+RUN wget https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz --no-check-certificate && \
+        tar -xzvf openvswitch-$OVS_VERSION.tar.gz &&\
+        mv openvswitch-$OVS_VERSION openvswitch &&\
+        cd openvswitch && \
+        ./configure && make && make install && cd .. && \
+        cp -r openvswitch/* / &&\
+        rm -r openvswitch &&\
+        rm openvswitch-$OVS_VERSION.tar.gz
 COPY . /go/src/github.com/cglewis/dovesnap
 WORKDIR /go/src/github.com/cglewis/dovesnap
 RUN dep ensure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3.7'
 services:
   plugin:
-    container_name: dovesnap
     image: cglewis/dovesnap
     build:
       context: .
@@ -16,7 +15,6 @@ services:
     command: -d
 
   ovs:
-    container_name: ovs
     image: openvswitch:2.13.0
     build:
       context: openvswitch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.7'
 services:
   plugin:
+    container_name: dovesnap
     image: cglewis/dovesnap
     build:
       context: .
@@ -15,6 +16,7 @@ services:
     command: -d
 
   ovs:
+    container_name: ovs
     image: openvswitch:2.13.0
     build:
       context: openvswitch

--- a/openvswitch/Dockerfile
+++ b/openvswitch/Dockerfile
@@ -1,19 +1,18 @@
 FROM debian:buster-slim
-ENV OVS_VERSION 2.13.0
 RUN apt-get update && apt-get install -y python3-pip python3 python python-setuptools make autoconf wget gcc git supervisor
 # Configure supervisord
 RUN mkdir -p /var/log/supervisor/
 ADD supervisord.conf /etc/
 # Install supervisor_stdout
 WORKDIR /opt
-RUN mkdir -p /var/log/supervisor/
-RUN mkdir -p /etc/openvswitch
 RUN git clone https://github.com/coderanger/supervisor-stdout && \
 	cd supervisor-stdout && \
 	python setup.py install -q
 # Get Open vSwitch
 WORKDIR /
+RUN mkdir -p /etc/openvswitch /usr/local/var/run/openvswitch
 RUN pip3 install six
+ENV OVS_VERSION 2.13.0
 RUN wget https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz --no-check-certificate && \
 	tar -xzvf openvswitch-$OVS_VERSION.tar.gz &&\
 	mv openvswitch-$OVS_VERSION openvswitch &&\
@@ -21,9 +20,7 @@ RUN wget https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz --
 	./configure && make && make install && cd .. && \
 	cp -r openvswitch/* / &&\
 	rm -r openvswitch &&\
-	rm openvswitch-$OVS_VERSION.tar.gz
+	rm openvswitch-$OVS_VERSION.tar.gz &&\
+        ovsdb-tool create /etc/openvswitch/conf.db /usr/local/share/openvswitch/vswitch.ovsschema
 ADD configure-ovs.sh /usr/local/share/openvswitch/
-RUN mkdir -p /usr/local/var/run/openvswitch
-# Create the database
-RUN ovsdb-tool create /etc/openvswitch/conf.db /usr/local/share/openvswitch/vswitch.ovsschema
 CMD ["/usr/bin/supervisord"]

--- a/openvswitch/Dockerfile
+++ b/openvswitch/Dockerfile
@@ -21,7 +21,7 @@ RUN wget https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz --
 	cp -r openvswitch/* / &&\
 	rm -r openvswitch &&\
 	rm openvswitch-$OVS_VERSION.tar.gz
-RUN mkdir -p /usr/local/var/run/openvswitch
+ADD configure-ovs.sh /usr/local/share/openvswitch/
 # Create the database
 RUN ovsdb-tool create /etc/openvswitch/conf.db /usr/local/share/openvswitch/vswitch.ovsschema
 ADD scripts /scripts

--- a/openvswitch/configure-ovs.sh
+++ b/openvswitch/configure-ovs.sh
@@ -2,8 +2,13 @@
 ovs_version=$(ovs-vsctl -V | grep ovs-vsctl | awk '{print $4}')
 ovs_db_version=$(ovsdb-tool schema-version /usr/local/share/openvswitch/vswitch.ovsschema)
 
+while ! ovs-vsctl show ; do
+	echo waiting for OVS
+	sleep 1
+done
+
 # begin configuring
-ovs-vsctl -- init
+ovs-vsctl --no-wait -- init
 ovs-vsctl --no-wait -- set Open_vSwitch . db-version="${ovs_db_version}"
 ovs-vsctl --no-wait -- set Open_vSwitch . ovs-version="${ovs_version}"
 ovs-vsctl --no-wait -- set Open_vSwitch . system-type="docker-ovs"

--- a/openvswitch/configure-ovs.sh
+++ b/openvswitch/configure-ovs.sh
@@ -2,10 +2,8 @@
 ovs_version=$(ovs-vsctl -V | grep ovs-vsctl | awk '{print $4}')
 ovs_db_version=$(ovsdb-tool schema-version /usr/local/share/openvswitch/vswitch.ovsschema)
 
-# give ovsdb-server and vswitchd some space...
-sleep 3
 # begin configuring
-ovs-vsctl --no-wait -- init
+ovs-vsctl --wait -- init
 ovs-vsctl --no-wait -- set Open_vSwitch . db-version="${ovs_db_version}"
 ovs-vsctl --no-wait -- set Open_vSwitch . ovs-version="${ovs_version}"
 ovs-vsctl --no-wait -- set Open_vSwitch . system-type="docker-ovs"

--- a/openvswitch/configure-ovs.sh
+++ b/openvswitch/configure-ovs.sh
@@ -3,7 +3,7 @@ ovs_version=$(ovs-vsctl -V | grep ovs-vsctl | awk '{print $4}')
 ovs_db_version=$(ovsdb-tool schema-version /usr/local/share/openvswitch/vswitch.ovsschema)
 
 # begin configuring
-ovs-vsctl --wait -- init
+ovs-vsctl -- init
 ovs-vsctl --no-wait -- set Open_vSwitch . db-version="${ovs_db_version}"
 ovs-vsctl --no-wait -- set Open_vSwitch . ovs-version="${ovs_version}"
 ovs-vsctl --no-wait -- set Open_vSwitch . system-type="docker-ovs"

--- a/openvswitch/supervisord.conf
+++ b/openvswitch/supervisord.conf
@@ -19,7 +19,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl = unix:///var/run/supervisor.sock
 
 [program:ovsdb-server]
-command=/usr/local/sbin/ovsdb-server /etc/openvswitch/conf.db --remote=punix:/usr/local/var/run/openvswitch/db.sock --remote=ptcp:6640 --pidfile=ovsdb-server.pid
+command=/usr/local/sbin/ovsdb-server -v /etc/openvswitch/conf.db --remote=punix:/usr/local/var/run/openvswitch/db.sock --remote=ptcp:6640 --pidfile=ovsdb-server.pid
 priority=10
 startsec=10
 stderr_events_enabled=true

--- a/ovs/ovs_bridge.go
+++ b/ovs/ovs_bridge.go
@@ -1,15 +1,22 @@
 package ovs
 
 import (
-	"errors"
 	"fmt"
-
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/iptables"
-	"github.com/socketplane/libovsdb"
 )
+
+// addBridge adds the OVS bridge
+func (ovsdber *ovsdber) addBridge(bridgeName string) error {
+        return VsCtl("add-br", bridgeName, "--", "set", "Bridge", bridgeName, "stp_enable=false")
+}
+
+// deleteBridge deletes the OVS bridge
+func (ovsdber *ovsdber) deleteBridge(bridgeName string) error {
+        return VsCtl("del-br", bridgeName)
+}
 
 //  setupBridge If bridge does not exist create it.
 func (d *Driver) initBridge(id string) error {
@@ -69,157 +76,6 @@ func (d *Driver) initBridge(id string) error {
 		return err
 	}
 
-	return nil
-}
-
-func (ovsdber *ovsdber) createBridgeIface(name string) error {
-	err := ovsdber.createOvsdbBridge(name)
-	if err != nil {
-		log.Errorf("Bridge creation failed for the bridge named [ %s ] with errors: %s", name, err)
-	}
-	return nil
-}
-
-// createOvsdbBridge creates the OVS bridge
-func (ovsdber *ovsdber) createOvsdbBridge(bridgeName string) error {
-	namedBridgeUUID := "bridge"
-	namedPortUUID := "port"
-	namedIntfUUID := "intf"
-
-	// intf row to insert
-	intf := make(map[string]interface{})
-	intf["name"] = bridgeName
-	intf["type"] = `internal`
-
-	insertIntfOp := libovsdb.Operation{
-		Op:       "insert",
-		Table:    "Interface",
-		Row:      intf,
-		UUIDName: namedIntfUUID,
-	}
-
-	// Port row to insert
-	port := make(map[string]interface{})
-	port["name"] = bridgeName
-	port["interfaces"] = libovsdb.UUID{namedIntfUUID}
-
-	insertPortOp := libovsdb.Operation{
-		Op:       "insert",
-		Table:    "Port",
-		Row:      port,
-		UUIDName: namedPortUUID,
-	}
-
-	// Bridge row to insert
-	bridge := make(map[string]interface{})
-	bridge["name"] = bridgeName
-	bridge["stp_enable"] = false
-	bridge["ports"] = libovsdb.UUID{namedPortUUID}
-
-	insertBridgeOp := libovsdb.Operation{
-		Op:       "insert",
-		Table:    "Bridge",
-		Row:      bridge,
-		UUIDName: namedBridgeUUID,
-	}
-
-	// Inserting a Bridge row in Bridge table requires mutating the open_vswitch table.
-	mutateUUID := []libovsdb.UUID{libovsdb.UUID{namedBridgeUUID}}
-	mutateSet, _ := libovsdb.NewOvsSet(mutateUUID)
-	mutation := libovsdb.NewMutation("bridges", "insert", mutateSet)
-	condition := libovsdb.NewCondition("_uuid", "==", libovsdb.UUID{ovsdber.getRootUUID()})
-
-	// Mutate operation
-	mutateOp := libovsdb.Operation{
-		Op:        "mutate",
-		Table:     "Open_vSwitch",
-		Mutations: []interface{}{mutation},
-		Where:     []interface{}{condition},
-	}
-
-	operations := []libovsdb.Operation{insertIntfOp, insertPortOp, insertBridgeOp, mutateOp}
-	reply, _ := ovsdber.ovsdb.Transact("Open_vSwitch", operations...)
-
-	if len(reply) < len(operations) {
-		return errors.New("Number of Replies should be at least equal to number of Operations")
-	}
-	for i, o := range reply {
-		if o.Error != "" && i < len(operations) {
-			return errors.New("Transaction Failed due to an error :" + o.Error + " details : " + o.Details)
-		} else if o.Error != "" {
-			return errors.New("Transaction Failed due to an error :" + o.Error + " details : " + o.Details)
-		}
-	}
-	return nil
-}
-
-// Check if port exists prior to creating a bridge
-func (ovsdber *ovsdber) addBridge(bridgeName string) error {
-	if ovsdber.ovsdb == nil {
-		return errors.New("OVS not connected")
-	}
-	// If the bridge has been created, an internal port with the same name will exist
-	exists, err := ovsdber.portExists(bridgeName)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		if err := ovsdber.createBridgeIface(bridgeName); err != nil {
-			return err
-		}
-		exists, err = ovsdber.portExists(bridgeName)
-		if err != nil {
-			return err
-		}
-		if !exists {
-			return errors.New("Error creating Bridge")
-		}
-	}
-	return nil
-}
-
-// deleteBridge deletes the OVS bridge
-func (ovsdber *ovsdber) deleteBridge(bridgeName string) error {
-	namedBridgeUUID := "bridge"
-
-	// simple delete operation
-	condition := libovsdb.NewCondition("name", "==", bridgeName)
-	deleteOp := libovsdb.Operation{
-		Op:    "delete",
-		Table: "Bridge",
-		Where: []interface{}{condition},
-	}
-
-	// Deleting a Bridge row in Bridge table requires mutating the open_vswitch table.
-	mutateUUID := []libovsdb.UUID{libovsdb.UUID{namedBridgeUUID}}
-	mutateSet, _ := libovsdb.NewOvsSet(mutateUUID)
-	mutation := libovsdb.NewMutation("bridges", "delete", mutateSet)
-
-	// simple mutate operation
-	mutateOp := libovsdb.Operation{
-		Op:        "mutate",
-		Table:     "Open_vSwitch",
-		Mutations: []interface{}{mutation},
-		Where:     []interface{}{condition},
-	}
-
-	operations := []libovsdb.Operation{deleteOp, mutateOp}
-	reply, _ := ovsdber.ovsdb.Transact("Open_vSwitch", operations...)
-
-	if len(reply) < len(operations) {
-		log.Error("Number of Replies should be atleast equal to number of Operations")
-	}
-	for i, o := range reply {
-		if o.Error != "" && i < len(operations) {
-			log.Error("Transaction Failed due to an error :", o.Error, " in ", operations[i])
-			errMsg := fmt.Sprintf("Transaction Failed due to an error: %s in operation: %v", o.Error, operations[i])
-			return errors.New(errMsg)
-		} else if o.Error != "" {
-			errMsg := fmt.Sprintf("Transaction Failed due to an error : %s", o.Error)
-			return errors.New(errMsg)
-		}
-	}
-	log.Debugf("OVSDB delete bridge transaction succesful")
 	return nil
 }
 

--- a/ovs/ovs_port.go
+++ b/ovs/ovs_port.go
@@ -21,114 +21,14 @@ func (ovsdber *ovsdber) createOvsInternalPort(prefix string, bridge string, tag 
 }
 
 func (ovsdber *ovsdber) addInternalPort(bridgeName string, portName string, tag uint) error {
-	namedPortUUID := "port"
-	namedIntfUUID := "intf"
-
-	// intf row to insert
-	intf := make(map[string]interface{})
-	intf["name"] = portName
-	intf["type"] = `internal`
-
-	insertIntfOp := libovsdb.Operation{
-		Op:       "insert",
-		Table:    "Interface",
-		Row:      intf,
-		UUIDName: namedIntfUUID,
+	if (tag != 0) {
+		return VsCtl("add-port", bridgeName, portName, fmt.Sprintf("tag=%u", tag))
 	}
-
-	// port row to insert
-	port := make(map[string]interface{})
-	port["name"] = portName
-	port["interfaces"] = libovsdb.UUID{namedIntfUUID}
-
-	if tag != 0 {
-		port["tag"] = tag
-	}
-
-	insertPortOp := libovsdb.Operation{
-		Op:       "insert",
-		Table:    "Port",
-		Row:      port,
-		UUIDName: namedPortUUID,
-	}
-
-	// Inserting a row in Port table requires mutating the bridge table.
-	mutateUUID := []libovsdb.UUID{libovsdb.UUID{namedPortUUID}}
-	mutateSet, _ := libovsdb.NewOvsSet(mutateUUID)
-	mutation := libovsdb.NewMutation("ports", "insert", mutateSet)
-	condition := libovsdb.NewCondition("name", "==", bridgeName)
-
-	// Mutate operation
-	mutateOp := libovsdb.Operation{
-		Op:        "mutate",
-		Table:     "Bridge",
-		Mutations: []interface{}{mutation},
-		Where:     []interface{}{condition},
-	}
-
-	operations := []libovsdb.Operation{insertIntfOp, insertPortOp, mutateOp}
-	reply, _ := ovsdber.ovsdb.Transact("Open_vSwitch", operations...)
-	if len(reply) < len(operations) {
-		log.Error("Number of Replies should be atleast equal to number of Operations")
-		return errors.New("Number of Replies should be atleast equal to number of Operations")
-	}
-	for i, o := range reply {
-		if o.Error != "" && i < len(operations) {
-			msg := fmt.Sprintf("Transaction Failed due to an error : %v details: %v in %v", o.Error, o.Details, operations[i])
-			return errors.New(msg)
-		} else if o.Error != "" {
-			msg := fmt.Sprintf("Transaction Failed due to an error : %v", o.Error)
-			return errors.New(msg)
-		}
-	}
-	return nil
+	return VsCtl("add-port", bridgeName, portName)
 }
 
 func (ovsdber *ovsdber) deletePort(bridgeName string, portName string) error {
-	condition := libovsdb.NewCondition("name", "==", portName)
-	deleteOp := libovsdb.Operation{
-		Op:    "delete",
-		Table: "Port",
-		Where: []interface{}{condition},
-	}
-
-	portUUID := portUUIDForName(portName)
-	if portUUID == "" {
-		log.Error("Unable to find a matching Port : ", portName)
-		return fmt.Errorf("Unable to find a matching Port : [ %s ]", portName)
-	}
-
-	// Deleting a Bridge row in Bridge table requires mutating the open_vswitch table.
-	mutateUUID := []libovsdb.UUID{libovsdb.UUID{portUUID}}
-	mutateSet, _ := libovsdb.NewOvsSet(mutateUUID)
-	mutation := libovsdb.NewMutation("ports", "delete", mutateSet)
-	condition = libovsdb.NewCondition("name", "==", bridgeName)
-
-	// simple mutate operation
-	mutateOp := libovsdb.Operation{
-		Op:        "mutate",
-		Table:     "Bridge",
-		Mutations: []interface{}{mutation},
-		Where:     []interface{}{condition},
-	}
-
-	operations := []libovsdb.Operation{deleteOp, mutateOp}
-	reply, _ := ovsdber.ovsdb.Transact("Open_vSwitch", operations...)
-
-	if len(reply) < len(operations) {
-		log.Error("Number of Replies should be atleast equal to number of Operations")
-		return fmt.Errorf("Number of Replies should be atleast equal to number of Operations")
-	}
-	for i, o := range reply {
-		if o.Error != "" && i < len(operations) {
-			log.Error("Transaction Failed due to an error :", o.Error, " in ", operations[i])
-			return fmt.Errorf("Transaction Failed due to an error: %s in %v", o.Error, operations[i])
-		} else if o.Error != "" {
-			log.Error("Transaction Failed due to an error :", o.Error)
-			return fmt.Errorf("Transaction Failed due to an error %s", o.Error)
-		}
-	}
-	return nil
+	return VsCtl("del-port", bridgeName, portName)
 }
 
 func (ovsdber *ovsdber) addVxlanPort(bridgeName string, portName string, peerAddress string) {
@@ -248,14 +148,4 @@ func (ovsdber *ovsdber) addOvsVethPort(bridgeName string, portName string, tag u
 		}
 	}
 	return nil
-}
-
-func portUUIDForName(portName string) string {
-	portCache := ovsdbCache["Port"]
-	for key, val := range portCache {
-		if val.Fields["name"] == portName {
-			return key
-		}
-	}
-	return ""
 }

--- a/ovs/ovsdb.go
+++ b/ovs/ovsdb.go
@@ -3,6 +3,7 @@ package ovs
 import (
 	"errors"
 	"fmt"
+	"os/exec"
 	"reflect"
 	"time"
 
@@ -24,6 +25,19 @@ var (
 	ovsdbCache   map[string]map[string]libovsdb.Row
 	contextCache map[string]string
 )
+
+func VsCtl(args ...string) (error) {
+        ovsvsctlPath := "/usr/local/bin/ovs-vsctl"
+        dbStr := fmt.Sprintf("--db=tcp:%s:%d", localhost, ovsdbPort)
+        all := append([]string{dbStr}, args...)
+        output, err := exec.Command(ovsvsctlPath, all...).CombinedOutput()
+        if err != nil {
+                log.Debugf("FAILED: %s, %v, %s", ovsvsctlPath, all, output)
+        } else {
+                log.Debugf("OK: %s, %v", ovsvsctlPath, all)
+        }
+        return err
+}
 
 type ovsdber struct {
 	ovsdb *libovsdb.OvsdbClient
@@ -128,7 +142,7 @@ func (ovsdber *ovsdber) monitorBridges() {
 							oldRow := row.Old
 							if _, ok := oldRow.Fields["name"]; ok {
 								name := oldRow.Fields["name"].(string)
-								ovsdber.createOvsdbBridge(name)
+								ovsdber.addBridge(name)
 							}
 						}
 					}


### PR DESCRIPTION
This fixes the bug that dovesnap can't delete a bridge, because it tries to control OVS' DB directly.
This is fragile, complex, and version dependant.

A future change will fix the VXLAN/veth add functions which the original author notes don't work
(because again they attempt to drive OVSDB directly, as above).

By using ovs-vsctl directly we can now easily add other bridge configuration (e.g. configurable DPID, OpenFlow controller, etc).